### PR TITLE
Fixed issue #4

### DIFF
--- a/contributextra.php
+++ b/contributextra.php
@@ -230,7 +230,7 @@ function contributextra_CRM_Contribute_Form_Search(&$form) {
     foreach($result['values'] as $page) {
       if (!empty($is_admin_page[$page['id']])) {
         $url = CRM_Utils_System::url('civicrm/contribute/transact','reset=1&cid='.$contactID.'&id='.$page['id']);
-        $backoffice_links[] = array('url' => $url, 'title' => $page['title']);
+        $backoffice_links[] = array('id' => $page['id'], 'url' => $url, 'title' => $page['title']);
       }
     }
   }
@@ -267,7 +267,7 @@ function contributextra_CRM_Contact_Page_View_Summary(&$page) {
     foreach($result['values'] as $contribution_page) {
       if (!empty($is_admin_page[$contribution_page['id']])) {
         $url = CRM_Utils_System::url('civicrm/contribute/transact','reset=1&cid='.$contactID.'&id='.$contribution_page['id']);
-        $backoffice_links[] = array('url' => $url, 'title' => $contribution_page['title']);
+        $backoffice_links[] = array('id' => $page['id'], 'url' => $url, 'title' => $contribution_page['title']);
       }
     }
   }

--- a/js/contact_summary.js
+++ b/js/contact_summary.js
@@ -11,7 +11,10 @@ cj(function ($) {
    var backofficeLinks = (typeof CRM.vars.contributextra != 'undefined') ? CRM.vars.contributextra.backofficeLinks : CRM.contributextra.backofficeLinks;
   if (0 < backofficeLinks.length) {
     $.each(backofficeLinks, function(index, value) {
-       $('#actions').append('<li><a style="color: #F88;" class="button" href="'+value.url+'">'+value.title+'</a></li>');
+      // Only add button if it's not already added
+      if( $('#actions').find('a.button.contributextra-btn[data-page-id='+value.id+']').length == 0 ){
+        $('#actions').append('<li><a style="color: #F88;" class="button contributextra-btn" href="'+value.url+'" data-page-id="'+value.id+'">'+value.title+'</a></li>');
+      }
     });
   }
 });

--- a/js/contribute_form_search.js
+++ b/js/contribute_form_search.js
@@ -13,7 +13,11 @@ cj(function ($) {
     var backofficeLinks = (typeof CRM.vars.contributextra != 'undefined') ? CRM.vars.contributextra.backofficeLinks : CRM.contributextra.backofficeLinks;
     if (0 < backofficeLinks.length) {
       $.each(backofficeLinks, function(index, value) {
-         $('form#Search').find('#help, .help').after(' <a style="color: #F88;" class="button" href="'+value.url+'">'+value.title+'</a>');
+        // Only add button if it's not already added
+        var siblings = $('form#Search').find('#help, .help').siblings('a.button.contributextra-btn');
+        if( siblings.length == 0 ){
+          $('form#Search').find('#help, .help').after(' <a style="color: #F88;" class="button contributextra-btn" href="'+value.url+'" data-page-id="'+value.id+'">'+value.title+'</a>');
+        }
       });
     }
   });


### PR DESCRIPTION
Fixed issue #4 where the extension injects duplicated admin-only contribution page buttons.

contributextra.php: include contribution page ID in data array so the JS can include ID in button. This lets the JS to accurately check for existing buttons before injecting new button, hense avoiding duplicates.

contact_summary.js:
- when adding button, include a unique class "contributextra-btn", and corresponding contribution page ID
- before adding button, check if the same button already exists. Only add button when it's not

contribute_form_search.js: same changes as contact_summary.js